### PR TITLE
Enable access to Test Run ID

### DIFF
--- a/step.rb
+++ b/step.rb
@@ -1,5 +1,7 @@
 require 'optparse'
 require 'pathname'
+require 'open3'
+require 'json'
 
 require_relative 'xamarin-builder/builder'
 
@@ -140,20 +142,32 @@ output.each do |_, project_output|
       request << options[:other_parameters]
 
       puts "  #{request.join(' ')}"
-      system(request.join(' '))
+      test_run_id = ""
 
-      unless $?.success?
-        file = File.open(@result_log_path)
-        contents = file.read
-        file.close
+      Open3.popen2e(request.join(' ')) do |stdin, stdout_err, wait_thr|
+          while line = stdout_err.gets
+              puts line
 
-        puts contents
-        fail_with_message("\e[31mFailed to upload to Xamarin Test Cloud\e[0m")
+              jsonObject = JSON.parse(line, symbolize_keys: true)
+              test_run_id = jsonObject["TestRunId"]
+              puts "Found Test Run ID #{test_run_id}"
+          end
+
+          exit_status = wait_thr.value
+          unless exit_status.success?
+              file = File.open(@result_log_path)
+              contents = file.read
+              file.close
+
+              puts contents
+              fail_with_message("\e[31mFailed to upload to Xamarin Test Cloud\e[0m")
+          end
       end
 
       #
       # Set output envs
       system('envman add --key BITRISE_XAMARIN_TEST_RESULT --value succeeded')
+      system("envman add --key BITRISE_XAMARIN_ANDROID_UITEST_RUN_ID --value #{test_run_id}")
       system("envman add --key BITRISE_XAMARIN_TEST_FULL_RESULTS_TEXT --value #{@result_log_path}") if @result_log_path
 
       puts "  \e[32mLogs are available at path:\e[0m #{@result_log_path}"

--- a/step.rb
+++ b/step.rb
@@ -103,7 +103,7 @@ begin
   builder.build
   builder.build_test
 rescue => ex
-  fail_with_message("Build failed: #{ex}")
+  fail_with_message("Build failed: #{ex} | Backtrace: #{ex.backtrace}")
 end
 
 output = builder.generated_files

--- a/step.yml
+++ b/step.yml
@@ -142,6 +142,9 @@ outputs:
       value_options:
       - succeeded
       - failed
+  - BITRISE_XAMARIN_ANDROID_UITEST_RUN_ID:
+    opts:
+      title: Run ID for the UI Tests session
   - BITRISE_XAMARIN_TEST_FULL_RESULTS_TEXT:
     opts:
       title: Result of the tests.


### PR DESCRIPTION
In order to do advanced work with the XTC Run ID, we need to get it first, so this PR helps in that direction.
